### PR TITLE
Feature: Subscribe Actor without to bus without Condition

### DIFF
--- a/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/BreezeMessageBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/BreezeMessageBus.scala
@@ -39,6 +39,9 @@ object BreezeMessageBus {
       val (actor, condition) = subscriber
       if(condition isMetBy event) actor ! event
     }
+
+    def subscribe(actor: ActorRef, to: Classifier): Boolean = super.subscribe((actor, new DefaultCondition), to)
+
   }
 
 }

--- a/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/BreezeMessageCondition.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/BreezeMessageCondition.scala
@@ -15,3 +15,14 @@ trait BreezeMessageCondition {
 
   def isMetBy(message: BreezeMessage): Boolean
 }
+
+/**
+ * Missing documentation.
+ *
+ * @author <a href="steffen.krause@soabridge.com">Steffen Krause</a>
+ * @since 1.0
+ */
+class DefaultCondition extends BreezeMessageCondition {
+
+  def isMetBy(message: BreezeMessage): Boolean = true
+}


### PR DESCRIPTION
This change will allow a developer to subscribe an actor to the `BreezeEventBus` without having to specify a message condition. A default condition will be instantiated and assigned to the actor. The default condition will always return true without checking the content of the message.
