### PR TITLE
Enhancement - Eventbus Cleanup

### DIFF
--- a/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/AbstractEventBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/framework/eventbus/AbstractEventBus.scala
@@ -13,7 +13,7 @@ import akka.util.Subclassification
  * @author <a href="steffen.krause@soabridge.com">Steffen Krause</a>
  * @since 1.0
  */
-abstract class BreezeBus extends EventBus with SubchannelClassification {
+abstract class AbstractEventBus extends EventBus with SubchannelClassification {
   type Classifier = Class[_ <: Event]
   type Subscriber = (ActorRef, EventCondition[Event])
 

--- a/src/main/scala/org/soabridge/scala/breeze/framework/eventing/AbstractEventBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/framework/eventing/AbstractEventBus.scala
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2016 SOABridge.org <http://www.soabridge.org>
  */
-package org.soabridge.scala.breeze.framework.eventbus
+package org.soabridge.scala.breeze.framework.eventing
 
 import akka.actor.ActorRef
 import akka.event.{EventBus, SubchannelClassification}

--- a/src/main/scala/org/soabridge/scala/breeze/framework/eventing/EventCondition.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/framework/eventing/EventCondition.scala
@@ -1,7 +1,7 @@
 /**
  * Copyright (C) 2016 SOABridge.org <http://www.soabridge.org>
  */
-package org.soabridge.scala.breeze.framework.eventbus
+package org.soabridge.scala.breeze.framework.eventing
 
 /**
  * Missing documentation.

--- a/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
@@ -4,7 +4,7 @@
 package org.soabridge.scala.breeze.messaging
 
 import akka.actor.ActorRef
-import org.soabridge.scala.breeze.framework.eventbus.BreezeBus
+import org.soabridge.scala.breeze.framework.eventbus.AbstractEventBus
 
 /**
  * Missing documentation.
@@ -12,7 +12,7 @@ import org.soabridge.scala.breeze.framework.eventbus.BreezeBus
  * @author <a href="steffen.krause@soabridge.com">Steffen Krause</a>
  * @since 1.0
  */
-class MessageBus(val name: String) extends BreezeBus {
+class MessageBus(val name: String) extends AbstractEventBus {
 
   type Event = BreezeMessage
 

--- a/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
@@ -1,10 +1,10 @@
 /**
  * Copyright (C) 2016 SOABridge.org <http://www.soabridge.org>
  */
-package org.soabridge.scala.breeze.framework.eventbus
+package org.soabridge.scala.breeze.messaging
 
 import akka.actor.ActorRef
-import org.soabridge.scala.breeze.messaging.{BreezeMessage, DefaultMessageCondition}
+import org.soabridge.scala.breeze.framework.eventbus.BreezeBus
 
 /**
  * Missing documentation.
@@ -12,7 +12,7 @@ import org.soabridge.scala.breeze.messaging.{BreezeMessage, DefaultMessageCondit
  * @author <a href="steffen.krause@soabridge.com">Steffen Krause</a>
  * @since 1.0
  */
-class BreezeMessageBus(val name: String) extends BreezeBus {
+class MessageBus(val name: String) extends BreezeBus {
 
   type Event = BreezeMessage
 
@@ -26,10 +26,10 @@ class BreezeMessageBus(val name: String) extends BreezeBus {
  * @author <a href="steffen.krause@soabridge.com">Steffen Krause</a>
  * @since 1.0
  */
-object BreezeMessageBus {
+object MessageBus {
 
-  def apply(): BreezeMessageBus = new BreezeMessageBus("default")
+  def apply(): MessageBus = new MessageBus("default")
 
-  def apply(name: String): BreezeMessageBus = new BreezeMessageBus(name)
+  def apply(name: String): MessageBus = new MessageBus(name)
 
 }

--- a/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/messaging/MessageBus.scala
@@ -4,7 +4,7 @@
 package org.soabridge.scala.breeze.messaging
 
 import akka.actor.ActorRef
-import org.soabridge.scala.breeze.framework.eventbus.AbstractEventBus
+import org.soabridge.scala.breeze.framework.eventing.AbstractEventBus
 
 /**
  * Missing documentation.

--- a/src/main/scala/org/soabridge/scala/breeze/messaging/MessageCondition.scala
+++ b/src/main/scala/org/soabridge/scala/breeze/messaging/MessageCondition.scala
@@ -3,7 +3,7 @@
  */
 package org.soabridge.scala.breeze.messaging
 
-import org.soabridge.scala.breeze.framework.eventbus.EventCondition
+import org.soabridge.scala.breeze.framework.eventing.EventCondition
 
 /**
  * Missing documentation.


### PR DESCRIPTION
_**Enhancements:**_
- Renamed `BreezeMessageBus` into `MessageBus`
- Moved `MessageBus` from framework package `eventbus` to `messaging`
- Renamed `BreezeBus` into `AbstractEventBus`
- Renamed framework package `eventbus` into `eventing`
